### PR TITLE
strange issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,11 @@
     <script type="text/javascript">
     var observer = new MutationObserver(function(mutations) {
       for(const mutation of mutations) {
-        if (mutation.addedNodes[0].outerHTML?.startsWith('<style')) {
-          console.log(mutation.addedNodes[0].outerHTML);
+        let node = mutation.addedNodes[0];
+        if (node.outerHTML?.startsWith('<style')) {
+          console.log(node.outerHTML);
+          const {sheet} = node;
+          console.log(sheet.cssRules);
           debugger;
         }
       }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,20 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 		<link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500&display=swap" rel="stylesheet">
     <title>Activities Dashboard</title>
+    <script type="text/javascript">
+    var observer = new MutationObserver(function(mutations) {
+      for(const mutation of mutations) {
+        if (mutation.addedNodes[0].outerHTML?.startsWith('<style')) {
+          console.log(mutation.addedNodes[0].outerHTML);
+          debugger;
+        }
+      }
+    });
+
+    observer.observe(document, {
+      attributes: false, childList: true, characterData: false, subtree: true
+    });
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -7,7 +7,7 @@ const card = ({ title, currentTime, previousTime, icon, lastTimeframe, cardBody 
 
 	return (
 		<div className="card">
-			<CardArt iconRef={iconRef} className="card__art">
+			<CardArt iconRef={iconRef} className="card__art" bgcolor="green">
 				<img src={icon} alt="" />
 			</CardArt>
 			<div className="card__header">

--- a/src/styles/styled-components.js
+++ b/src/styles/styled-components.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 const CardArt = styled.div`
+  border: 2px solid ${props => props.bgcolor};
 	background: ${props => `var(--theme-${props.iconRef});`}
 `;
 

--- a/src/styles/styled-components.js
+++ b/src/styles/styled-components.js
@@ -2,7 +2,9 @@ import styled from "styled-components";
 
 const CardArt = styled.div`
   border: 2px solid ${props => props.bgcolor};
-	background: ${props => `var(--theme-${props.iconRef});`}
+  &:after {
+    content: "${props => `${props.iconRef}`}";
+  }
 `;
 
 export default CardArt;


### PR DESCRIPTION
Tried running your code to investigate styled component not working in dist...

I'm confused by what I found...

`yarn build && yarn preview` then visit http://localhost:4173/ with dev tools open so the debugger triggers

Dev tool console logs:

`<style data-styled="active" data-styled-version="5.3.3"></style>`

Inspect the first card element...

<img width="719" alt="image" src="https://user-images.githubusercontent.com/990216/157814993-469e86e0-cc16-49c3-ba4c-528340f5f7fb.png">

You see that style:

<img width="365" alt="image" src="https://user-images.githubusercontent.com/990216/157815141-dc97cd44-75e2-4323-b987-820362725b45.png">

Is applied by `<style>`... Click `<style>` and see it references the tag added by styled-components:

<img width="543" alt="image" src="https://user-images.githubusercontent.com/990216/157815285-3e996dbc-81c0-44d2-8a52-a33b1d808bb7.png">

This is where things get strange. Notice the `<style data-styled="active" data-styled-version="5.3.3"></style>` has no styles or content... Yet somehow this tag is supposedly applying the green border?

Try deleting the tag and the green borders dissapear. CMD+Z and the `<style data-styled="active" ...` reappears in the DOM inspector where it was before but the green borders do not reappear...

<img width="724" alt="image" src="https://user-images.githubusercontent.com/990216/157816105-f1f08f71-9f60-4485-b0f1-abec4fd450ae.png">

I don't understand how this tag can be applying styles to elements when it has not content... So strange.